### PR TITLE
Fix copy and paste bugs

### DIFF
--- a/chapter/16/workflow/internal/service/jobs/register/tokenbucket/tokenbucket.go
+++ b/chapter/16/workflow/internal/service/jobs/register/tokenbucket/tokenbucket.go
@@ -3,9 +3,12 @@ Package tokenbucket registers a job that is used to fetch a token from a token b
 
 Register name: "tokenBucket"
 Args:
+
 	"bucket"(mandatory): The name of the bucket
 	"fatal"(mandatory): true if a failure should cause a fatal error, false if it should block until it gets one
+
 Result:
+
 	If the site is not in decom, will return a fatal error.
 */
 package tokenbucket
@@ -59,7 +62,7 @@ func (a *args) validate(args map[string]string) error {
 			case "true":
 				a.fatal = true
 			case "false":
-				a.fatal = true
+				a.fatal = false
 			default:
 				return fmt.Errorf("arg(fatal) was not true or false, was %q", v)
 			}

--- a/chapter/8/rollout/lb/client/cli/cli.go
+++ b/chapter/8/rollout/lb/client/cli/cli.go
@@ -75,7 +75,7 @@ func main() {
 			Port:    int32(*port),
 			URLPath: *urlPath,
 		}
-		if err := c.AddBackend(ctx, *pattern, b); err != nil {
+		if err := c.RemoveBackend(ctx, *pattern, b); err != nil {
 			panic(err)
 		}
 	case "poolHealth":


### PR DESCRIPTION
I was write a linter  https://github.com/alingse/copyandpaste that detect the same code in different branch.

this is mostly a copy and paste things. 

I search and post the popular repo in the github and run the workflow.

Here is this repo's result log.

```
Error: /home/runner/work/copyandpaste/copyandpaste/Go-for-DevOps/chapter/16/workflow/internal/service/jobs/register/tokenbucket/tokenbucket.go:61:4: Duplicate case body found for case "false": and case "true": Is it a copy and paste?
Error: /home/runner/work/copyandpaste/copyandpaste/Go-for-DevOps/chapter/8/rollout/lb/client/cli/cli.go:[7](https://github.com/alingse/copyandpaste/actions/runs/7476736381/job/20347830235#step:7:8)0:2: Duplicate case body found for case "removeBackend": and case "addBackend": Is it a copy and paste?
```

from the code context. I think these two is a bug.
